### PR TITLE
namespace correction.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,27 +18,27 @@ find_package(std_msgs REQUIRED)
 
 include_directories(include)
 
-add_library(topics_library SHARED
+add_library(topics_library_high_freq SHARED
   src/talker.cpp
   src/listener.cpp)
 
-target_compile_definitions(topics_library
-  PRIVATE "DEMO_NODES_CPP_BUILDING_DLL")
-ament_target_dependencies(topics_library
+target_compile_definitions(topics_library_high_freq
+  PRIVATE "HIGH_FREQ_PUB_BUILDING_DLL")
+ament_target_dependencies(topics_library_high_freq
   "rclcpp"
   "rclcpp_components"
   "std_msgs")
 
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::Talker"
+rclcpp_components_register_node(topics_library_high_freq
+  PLUGIN "high_freq_pub::Talker"
   EXECUTABLE talker)
 
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::Listener"
+rclcpp_components_register_node(topics_library_high_freq
+  PLUGIN "high_freq_pub::Listener"
   EXECUTABLE listener)
 
 install(TARGETS
-  topics_library
+  topics_library_high_freq
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)

--- a/include/high_freq_pub/visibility_control.h
+++ b/include/high_freq_pub/visibility_control.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DEMO_NODES_CPP__VISIBILITY_CONTROL_H_
-#define DEMO_NODES_CPP__VISIBILITY_CONTROL_H_
+#ifndef HIGH_FREQ_PUB__VISIBILITY_CONTROL_H_
+#define HIGH_FREQ_PUB__VISIBILITY_CONTROL_H_
 
 #ifdef __cplusplus
 extern "C"
@@ -25,34 +25,34 @@ extern "C"
 
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef __GNUC__
-    #define DEMO_NODES_CPP_EXPORT __attribute__ ((dllexport))
-    #define DEMO_NODES_CPP_IMPORT __attribute__ ((dllimport))
+    #define HIGH_FREQ_PUB_EXPORT __attribute__ ((dllexport))
+    #define HIGH_FREQ_PUB_IMPORT __attribute__ ((dllimport))
   #else
-    #define DEMO_NODES_CPP_EXPORT __declspec(dllexport)
-    #define DEMO_NODES_CPP_IMPORT __declspec(dllimport)
+    #define HIGH_FREQ_PUB_EXPORT __declspec(dllexport)
+    #define HIGH_FREQ_PUB_IMPORT __declspec(dllimport)
   #endif
-  #ifdef DEMO_NODES_CPP_BUILDING_DLL
-    #define DEMO_NODES_CPP_PUBLIC DEMO_NODES_CPP_EXPORT
+  #ifdef HIGH_FREQ_PUB_BUILDING_DLL
+    #define HIGH_FREQ_PUB_PUBLIC HIGH_FREQ_PUB_EXPORT
   #else
-    #define DEMO_NODES_CPP_PUBLIC DEMO_NODES_CPP_IMPORT
+    #define HIGH_FREQ_PUB_PUBLIC HIGH_FREQ_PUB_IMPORT
   #endif
-  #define DEMO_NODES_CPP_PUBLIC_TYPE DEMO_NODES_CPP_PUBLIC
-  #define DEMO_NODES_CPP_LOCAL
+  #define HIGH_FREQ_PUB_PUBLIC_TYPE HIGH_FREQ_PUB_PUBLIC
+  #define HIGH_FREQ_PUB_LOCAL
 #else
-  #define DEMO_NODES_CPP_EXPORT __attribute__ ((visibility("default")))
-  #define DEMO_NODES_CPP_IMPORT
+  #define HIGH_FREQ_PUB_EXPORT __attribute__ ((visibility("default")))
+  #define HIGH_FREQ_PUB_IMPORT
   #if __GNUC__ >= 4
-    #define DEMO_NODES_CPP_PUBLIC __attribute__ ((visibility("default")))
-    #define DEMO_NODES_CPP_LOCAL  __attribute__ ((visibility("hidden")))
+    #define HIGH_FREQ_PUB_PUBLIC __attribute__ ((visibility("default")))
+    #define HIGH_FREQ_PUB_LOCAL  __attribute__ ((visibility("hidden")))
   #else
-    #define DEMO_NODES_CPP_PUBLIC
-    #define DEMO_NODES_CPP_LOCAL
+    #define HIGH_FREQ_PUB_PUBLIC
+    #define HIGH_FREQ_PUB_LOCAL
   #endif
-  #define DEMO_NODES_CPP_PUBLIC_TYPE
+  #define HIGH_FREQ_PUB_PUBLIC_TYPE
 #endif
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // DEMO_NODES_CPP__VISIBILITY_CONTROL_H_
+#endif  // HIGH_FREQ_PUB__VISIBILITY_CONTROL_H_

--- a/src/listener.cpp
+++ b/src/listener.cpp
@@ -10,15 +10,15 @@
 
 using namespace std::chrono_literals;
 
-namespace demo_nodes_cpp
+namespace high_freq_pub
 {
 
 class Listener : public rclcpp::Node
 {
 public:
-    DEMO_NODES_CPP_PUBLIC
+    HIGH_FREQ_PUB_PUBLIC
     explicit Listener(const rclcpp::NodeOptions& options)
-        : Node("listener", options),
+        : Node("listener_high_freq", options),
           m_messageID(0),
           m_numReceivedMsgs(0)
     {
@@ -56,6 +56,6 @@ private:
     int32_t m_numReceivedMsgs;
 };
 
-}  // namespace demo_nodes_cpp
+}  // namespace high_freq_pub
 
-RCLCPP_COMPONENTS_REGISTER_NODE(demo_nodes_cpp::Listener)
+RCLCPP_COMPONENTS_REGISTER_NODE(high_freq_pub::Listener)

--- a/src/talker.cpp
+++ b/src/talker.cpp
@@ -12,15 +12,15 @@
 
 using namespace std::chrono_literals;
 
-namespace demo_nodes_cpp
+namespace high_freq_pub
 {
 
 class Talker : public rclcpp::Node
 {
 public:
-    DEMO_NODES_CPP_PUBLIC
+    HIGH_FREQ_PUB_PUBLIC
     explicit Talker(const rclcpp::NodeOptions& options)
-        : Node("talker", options)
+        : Node("talker_high_freq", options)
     {
         setvbuf(stdout, NULL, _IONBF, BUFSIZ);
         auto publish_message =
@@ -52,6 +52,6 @@ private:
     rclcpp::TimerBase::SharedPtr timer_;
 };
 
-}  // namespace demo_nodes_cpp
+}  // namespace high_freq_pub
 
-RCLCPP_COMPONENTS_REGISTER_NODE(demo_nodes_cpp::Talker)
+RCLCPP_COMPONENTS_REGISTER_NODE(high_freq_pub::Talker)


### PR DESCRIPTION
correct namespace for this test program.
this will avoid to load demo_node_cpp talker/listener with ros2 source build environment.